### PR TITLE
memberRepository Junit4 test

### DIFF
--- a/src/main/java/jpabook/jpashop/repository/MemberRepository.java
+++ b/src/main/java/jpabook/jpashop/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package jpabook.jpashop.repository;
 
 import jpabook.jpashop.domain.Member;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
@@ -8,6 +9,7 @@ import javax.persistence.PersistenceContext;
 import java.util.List;
 
 @Repository // 자동으로 스프링 빈으로 등록
+@RequiredArgsConstructor // final이 붙은 멤버변수를 대상으로 자동으로 생성자를 만들어줌! (생성자로 객체를 생성함과 동시에 의존성 주입까지!)
 public class MemberRepository {
 
     /**
@@ -18,7 +20,11 @@ public class MemberRepository {
      * 트랜잭션 커밋과 try~catch로 예외를 잡아줘야 한다.
      */
     @PersistenceContext
-    private EntityManager em;
+    private final EntityManager em;
+
+    /*public MemberRepository(EntityManager em) {
+        this.em = em;
+    }*/
 
     // 회원 저장
     public void save(Member member) {

--- a/src/main/java/jpabook/jpashop/service/MemberService.java
+++ b/src/main/java/jpabook/jpashop/service/MemberService.java
@@ -2,18 +2,30 @@ package jpabook.jpashop.service;
 
 import jpabook.jpashop.domain.Member;
 import jpabook.jpashop.repository.MemberRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service // 컴포넌트 스캔의 대상이 됨 ->  스프링 빈으로 등록됨
-@Transactional // 데이터의 변경은 트랜잭션 안에서 실행되어야 함, class 레벨에서 사용하면 public 메소드들은 모두 트랜잭션이 적용된다.
+// JPA 조회 성능 최적화, 데이터의 변경은 트랜잭션 안에서 실행되어야 함
+// class 레벨에서 사용하면 public 메소드들은 모두 트랜잭션이 적용된다.
+@Transactional(readOnly = true)
+// @AllArgsConstructor // 모든 멤버변수를 대상으로 생성자를 만들어준다. (아래 생성자 코드를 적지 않아도 된다!)
+@RequiredArgsConstructor // final 이 붙은 멤버변수를 대상으로 생성자를 만들어준다!
 public class MemberService {
 
-    @Autowired
-    private MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
+
+    // 세터 인젝션은 테스트는 용이하지만, 외부에서 세터를 호출해 값을 수정할 수 있기 때문에 위험하다. -> 사용x
+    // 생성자 인젝션을 사용하자.
+    // 테스트도 용이하며, 외부 수정도 불가능하고, 런타임까지 가지 않고
+    // 컴파일에서 오류를 알려줘 의존성 빈을 미리 설정할 수 있다.
+    // @Autowired // 생성자가 1개인 경우는 @Autowired 생략 가능
+    /*public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }*/
 
     /**
      * 회원 가입
@@ -21,6 +33,7 @@ public class MemberService {
      * @param member
      * @return
      */
+    @Transactional
     public Long join(Member member) {
 
         // 중복 회원 검증
@@ -31,6 +44,10 @@ public class MemberService {
         return member.getId();
     }
 
+    // 와스가 여러개인 실무에서는 API로 중복 회원을 검증해도 문제가 생길 수 있다.
+    // 여러 와스에 멀티 쓰레드 환경에서 동시에 member.save() 를 호출하는 상황이 있을 수 있다.
+    // 그렇게 때문에, API 에서 해당 검증을 처리한다고 해도, 최종적으로는
+    // DB 에서도 유니크 제약을 설정해야 한다.
     private void validateDuplicateMember(Member member) {
         List<Member> findMembers = memberRepository.findByName(member.getName());
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,7 @@ spring:
 logging:
   level:
     org.hibernate.SQL: debug
+    org.hibernate.type: trace
 
 # show_sql : 옵션은 System.out 에 하이버네이트 실행 SQL을 남긴다.
 # org.hibernate.SQL : 옵션은 logger를 통해 하이버네이트 실행 SQL을 남긴다.

--- a/src/test/java/jpabook/jpashop/service/MemberServiceTest.java
+++ b/src/test/java/jpabook/jpashop/service/MemberServiceTest.java
@@ -1,0 +1,90 @@
+package jpabook.jpashop.service;
+
+import jpabook.jpashop.domain.Member;
+import jpabook.jpashop.repository.MemberRepository;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(SpringRunner.class) // JUnit 실행 시 Spring 도 사용해서 테스트
+@SpringBootTest // Spring Boot를 띄운 상태에서 테스트(없으면 의존성 주입이 안되므로 @Autowired 모두 실패함)
+// @Transactional 의 기본 전략은 롤백이다. 커밋 x
+// -> 즉, JPA 사용 시 트랜잭션 커밋이 되지 않기 때문에 영속성 컨텍스트에서만 쿼리가 날라가고 실제 DB 까지는 쿼리가 전달되지 않는다.
+@Transactional // crud 기능 테스트를 위해 트랜잭셔널 적용 (적용해야 롤백 가능, 테스트니까 롤백해야함!)
+public class MemberServiceTest {
+
+    @Autowired
+    MemberService memberService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+//    @Rollback(false) // @Transactional 의 기본 전략인 롤백 true 말고 false 적용해야 실제 db에 쿼리가 날라가는 것을 볼 수 있음.
+    public void 회원가입() {
+
+        // given (~이 주어졌을 때 == 조건)
+        Member member = new Member();
+        member.setName("kim");
+
+        // when (~으로 하면 == 상황)
+        Long savedId = memberService.join(member);
+
+        // then (~의 결과가 나와? == 결과)
+        em.flush(); // DB 쿼리 날림! (영속성 컨텍스트와 실제 DB의 싱크를 맞춤, 이후 @Transactional 기본 전략인 롤백이 적용되므로 DB에는 다시 데이터가 롤백됨)
+        assertEquals(member, memberRepository.findOne(savedId));
+    }
+
+    /**
+     * member2를 join하면 예외가 발생한다.
+     * 예외를 잡아주지 않으면 와스까지 나가버림
+     * try catch 로 예외가 발생하면 return 해서 예외를 여기서 잡아주자.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void 중복_회원_예외() {
+
+        // given
+        Member member1 = new Member();
+        member1.setName("kim");
+
+        Member member2 = new Member();
+        member2.setName("kim");
+
+        // when
+        memberService.join(member1);
+        memberService.join(member2);
+        /*try {
+            memberService.join(member2);
+            // 같은 이름의 회원을 넣음 -> 예외가 발생해야 한다!!!!
+        } catch (IllegalStateException e) {
+            return;
+            // member2를 join하면 예외가 발생한다.
+            // 예외를 잡아주지 않으면 와스까지 나가버림
+            // try catch 로 예외가 발생하면 return 해서 예외를 여기서 잡아주자.
+        }*/
+
+        // then
+        fail("예외가 발생해야 한다.");
+    }
+
+    @Test
+    public void findOne() {
+
+        // given
+
+        // when
+
+        // then
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,30 @@
+spring:
+#  datasource:
+#    url: jdbc:h2:mem:test # Test 시 인메모리 H2 DB 사용 설정
+#    username: sa
+#    password: sa
+#    driver-class-name: org.h2.Driver
+#
+#  jpa:
+#    hibernate:
+#      ddl-auto: create-drop
+#    properties:
+#      hibernate:
+#        format_sql: true
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type: trace
+
+# Test 환경에서는 test 패키지 하위의 resources 로 만들어준 패키지를 기준으로 애플리케이션을 설정한다.
+
+# Test 환경에서 (기본적으로 트랜잭셔널이 디폴트 롤백을 실행하긴 하지만) 실제 물리 DB에
+# 데이터를 남기고 롤백하는 과정이 번거로울 수 있다.
+# (실무에서는 테스트 서버도 여러개, 테스트 DB도 여러개일 수 있음)
+# 그래서 실제 물리 DB가 아닌 인메모리 DB를 사용해서 테스트를 해보자.
+
+# gradle 라이브러리에 H2 데이터베이스가 들어가 있다.
+# H2는 JVM 으로 메모리에 띄울 수 있다.
+
+# 더 대박적인 것은 SpringBoot 에서는 기본 DB 설정이 없으면 디폴트로 인메모리로 돌려버린당..


### PR DESCRIPTION
@RunWith(SpringRunner.class) // JUnit 실행 시 Spring 도 사용해서 테스트
@SpringBootTest // Spring Boot를 띄운 상태에서 테스트(없으면 의존성 주입이 안되므로 @Autowired 모두 실패함)
// @Transactional 의 기본 전략은 롤백이다. 커밋 x
// -> 즉, JPA 사용 시 트랜잭션 커밋이 되지 않기 때문에 영속성 컨텍스트에서만 쿼리가 날라가고 실제 DB 까지는 쿼리가 전달되지 않는다.
@Transactional // crud 기능 테스트를 위해 트랜잭셔널 적용 (적용해야 롤백 가능, 테스트니까 롤백해야함!)

# Test 환경에서는 test 패키지 하위의 resources 로 만들어준 패키지를 기준으로 애플리케이션을 설정한다.

# Test 환경에서 (기본적으로 트랜잭셔널이 디폴트 롤백을 실행하긴 하지만) 실제 물리 DB에
# 데이터를 남기고 롤백하는 과정이 번거로울 수 있다.
# (실무에서는 테스트 서버도 여러개, 테스트 DB도 여러개일 수 있음)
# 그래서 실제 물리 DB가 아닌 인메모리 DB를 사용해서 테스트를 해보자.

# gradle 라이브러리에 H2 데이터베이스가 들어가 있다.
# H2는 JVM 으로 메모리에 띄울 수 있다.

# 더 대박적인 것은 SpringBoot 에서는 기본 DB 설정이 없으면 디폴트로 인메모리로 돌려버린당..